### PR TITLE
Only address the panic in IDP-initiated login

### DIFF
--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -183,13 +183,13 @@ func (m *Middleware) getPossibleRequestIDs(r *http.Request) []string {
 			m.ServiceProvider.Logger.Printf("... invalid token %s", err)
 			continue
 		}
+		// If IDP initiated requests are allowed, then we can expect an empty response ID.
 		claims := token.Claims.(jwt.MapClaims)
 		if id, ok := claims["id"]; ok {
 			rv = append(rv, id.(string))
 		}
 	}
 
-	// If IDP initiated requests are allowed, then we can expect an empty response ID.
 	if m.AllowIDPInitiated {
 		rv = append(rv, "")
 	}
@@ -206,33 +206,28 @@ func (m *Middleware) Authorize(w http.ResponseWriter, r *http.Request, assertion
 	redirectURI := "/"
 	if relayState := r.Form.Get("RelayState"); relayState != "" {
 		stateValue := m.ClientState.GetState(r, relayState)
-		if stateValue != "" {
-			jwtParser := jwt.Parser{
-				ValidMethods: []string{jwtSigningMethod.Name},
-			}
-			state, err := jwtParser.Parse(stateValue, func(t *jwt.Token) (interface{}, error) {
-				return secretBlock, nil
-			})
-			if err != nil || !state.Valid {
-				m.ServiceProvider.Logger.Printf("Cannot decode state JWT: %s (%s)", err, stateValue)
-				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
-				return
-			}
-			claims := state.Claims.(jwt.MapClaims)
-			redirectURI = claims["uri"].(string)
-
-			// delete the cookie
-			m.ClientState.DeleteState(w, r, relayState)
-		} else if m.AllowIDPInitiated {
-			// If the state value couldn't be retrieved for the RelayState, and IDP-initiated flows are allowed
-			// then use the RelayState value as the redirect URI itself.
-			redirectURI = relayState
-		} else {
-			// Otherwise, redirect the user with a 403.
+		if stateValue == "" {
 			m.ServiceProvider.Logger.Printf("cannot find corresponding state: %s", relayState)
 			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 			return
 		}
+
+		jwtParser := jwt.Parser{
+			ValidMethods: []string{jwtSigningMethod.Name},
+		}
+		state, err := jwtParser.Parse(stateValue, func(t *jwt.Token) (interface{}, error) {
+			return secretBlock, nil
+		})
+		if err != nil || !state.Valid {
+			m.ServiceProvider.Logger.Printf("Cannot decode state JWT: %s (%s)", err, stateValue)
+			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+			return
+		}
+		claims := state.Claims.(jwt.MapClaims)
+		redirectURI = claims["uri"].(string)
+
+		// delete the cookie
+		m.ClientState.DeleteState(w, r, relayState)
 	}
 
 	now := saml.TimeNow()


### PR DESCRIPTION
This change undoes some of the changes made in 4908b2671cdbd0cc707f66eadcc570c438d8919e, to just address the panic for IDP-initiated logins.

I'll file an issue in the `crewjam/saml` repo about the other issue blocking IDP-initiated logins, which is how to support relay states from the IDP.